### PR TITLE
Typedef and resolvers

### DIFF
--- a/_db.js
+++ b/_db.js
@@ -1,0 +1,26 @@
+// This file is used to simulate a database for the purpose of this project.
+let games = [
+  {id: '1', title: 'XCOM: UFO Defense', platform: ['DOS', 'PS', 'Amiga']},
+  {id: '2', title: 'XCOM: Terror from the Deep', platform: ['DOS', 'PS']},
+  {id: '3', title: 'XCOM: Apocalypse', platform: ['DOS']},
+  {id: '4', title: 'XCOM: Enemy Unknown', platform: ['Windows', 'Xbox 360', 'PS3']},
+  {id: '5', title: 'XCOM2', platform: ['Windows', 'Xbox One', 'PS4']},
+]
+
+let authors = [
+  {id: '1', name: 'Mario', verified: true},
+  {id: '2', name: 'Yoshi', verified: false},
+  {id: '3', name: 'Peach', verified: true},
+]
+
+let reviews = [
+  {id: '1', rating: 9, content: 'Lorem ipsum', author_id: '1', game_id: '2'},
+  {id: '2', rating: 10, content: 'Lorem ipsum', author_id: '2', game_id: '1'},
+  {id: '3', rating: 7, content: 'Lorem ipsum', author_id: '3', game_id: '3'},
+  {id: '4', rating: 5, content: 'Lorem ipsum', author_id: '2', game_id: '4'},
+  {id: '5', rating: 8, content: 'Lorem ipsum', author_id: '2', game_id: '5'},
+  {id: '6', rating: 7, content: 'Lorem ipsum', author_id: '1', game_id: '2'},
+  {id: '7', rating: 10, content: 'Lorem ipsum', author_id: '3', game_id: '1'},
+]
+
+export default { games, authors, reviews }

--- a/index.js
+++ b/index.js
@@ -1,8 +1,12 @@
 import { ApolloServer } from '@apollo/server';
 import { startStandaloneServer } from '@apollo/server/standalone';
 
+// import type definitions
+import { typeDefs } from './schema.js';
+
 // Set up apollo server
 const server = new ApolloServer({
+  typeDefs,
 });
 
 const { url } = await startStandaloneServer(server, {

--- a/index.js
+++ b/index.js
@@ -1,12 +1,31 @@
 import { ApolloServer } from '@apollo/server';
 import { startStandaloneServer } from '@apollo/server/standalone';
 
+// DB
+import db from './_db.js';
+
 // import type definitions
 import { typeDefs } from './schema.js';
+
+const resolvers = {
+  // match the Query type in schema.js
+  Query: {
+    games() {
+      return db.games
+    },
+    authors() {
+      return db.authors
+    },
+    reviews() {
+      return db.reviews
+    }
+  }
+};
 
 // Set up apollo server
 const server = new ApolloServer({
   typeDefs,
+  resolvers
 });
 
 const { url } = await startStandaloneServer(server, {

--- a/schema.js
+++ b/schema.js
@@ -1,0 +1,28 @@
+// Supported scalar types: Int, Float, String, Boolean, and ID.
+// Exclamation (!) idicates that the field is required.
+//
+// For example, [String!]! indicates that the field is an array of strings that
+// cannot be null or empty.
+
+export const typeDefs = `#graphql
+  type Game {
+    id: ID!
+    name: String!
+    platform: [String!]!
+  }
+  type Review {
+    id: ID!
+    rating: Int!
+    content: String!
+  }
+  type Author {
+    id: ID!
+    name: String!
+    verified: Boolean!
+  }
+  type Query {
+    reviews: [Review]
+    games: [Game]
+    authors: [Author]
+  }
+`


### PR DESCRIPTION
Add typeDefs and resolvers.

A schema is a collection of type definitions (hence "typeDefs").
Resolvers tell Apollo Server how to fetch the data associated with a particular type.