### PR TITLE
Nested resources

### DIFF
--- a/_db.js
+++ b/_db.js
@@ -13,12 +13,13 @@ let authors = [
   {id: '3', name: 'Peach', verified: true},
 ]
 
+// a middle table between games and authors
 let reviews = [
   {id: '1', rating: 9, content: 'Lorem ipsum', author_id: '1', game_id: '2'},
   {id: '2', rating: 10, content: 'Lorem ipsum', author_id: '2', game_id: '1'},
   {id: '3', rating: 7, content: 'Lorem ipsum', author_id: '3', game_id: '3'},
   {id: '4', rating: 5, content: 'Lorem ipsum', author_id: '2', game_id: '4'},
-  {id: '5', rating: 8, content: 'Lorem ipsum', author_id: '2', game_id: '5'},
+  {id: '5', rating: 8, content: 'Lorem ipsum', author_id: '2', game_id: '4'},
   {id: '6', rating: 7, content: 'Lorem ipsum', author_id: '1', game_id: '2'},
   {id: '7', rating: 10, content: 'Lorem ipsum', author_id: '3', game_id: '1'},
 ]

--- a/index.js
+++ b/index.js
@@ -28,6 +28,24 @@ const resolvers = {
     review(_, args) {
       return db.reviews.find(review => review.id === args.id)
     }
+  },
+  Game: {
+    reviews(parent) {
+      return db.reviews.filter(review => review.game_id === parent.id)
+    }
+  },
+  Review: {
+    author(parent) {
+      return db.authors.find(author => author.id === parent.author_id)
+    },
+    game(parent) {
+      return db.games.find(game => game.id === parent.game_id )
+    },
+  },
+  Author: {
+    reviews(parent) {
+      return db.reviews.filter(reviews => reviews.author_id === parent.id)
+    }
   }
 };
 

--- a/schema.js
+++ b/schema.js
@@ -1,24 +1,32 @@
 // Supported scalar types: Int, Float, String, Boolean, and ID.
-// Exclamation (!) idicates that the field is required.
+// Exclamation (!) idicates that the field is non-nullable.
 //
-// For example, [String!]! indicates that the field is an array of strings that
-// cannot be null or empty.
+// [String!]! means that each element of the array cannot be null,
+// and the array itself cannot be null.
+// [Review!] means the each element of the array cannot be null,
+// but the array itself can be null.
+//
+// Note: Whether there's an outer exclamation mark or not, an empty array [] is always valid.
 
 export const typeDefs = `#graphql
   type Game {
     id: ID!
-    name: String!
+    title: String!
     platform: [String!]!
+    reviews: [Review!]
   }
   type Review {
     id: ID!
     rating: Int!
     content: String!
+    author: Author!
+    game: Game!
   }
   type Author {
     id: ID!
     name: String!
     verified: Boolean!
+    reviews: [Review!]
   }
   type Query {
     reviews: [Review]


### PR DESCRIPTION
This allows you to request associated data as an expanded response (like what you've seen on Stipe API). You can expand recursively by specifying nested fields.

In the following example, the `game` response is expanded to `reviews` and `author`.
```graphql
query Game($id: ID!) {
  game(id: $id) {
    id,
    title,
    platform,
    reviews {
      rating,
      content,
      author {
        name
      }
    }
  }
}
```

A response example is as follows.
```json
{
  "data": {
    "game": {
      "id": "3",
      "title": "XCOM: Apocalypse",
      "platform": [
        "DOS"
      ],
      "reviews": [
        {
          "rating": 8,
          "content": "colorful, almost humorous tone",
          "author": {
            "name": "GameSpot"
          }
        }
      ]
    }
  }
}
```